### PR TITLE
Adding Docker Support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,7 +5,7 @@ FROM alpine/git:latest
 RUN git clone https://github.com/piyx/YoutubeSpotifyDL.git /opt/app
 
 # Pull base image for python.
-FROM python:3.8-slim
+FROM python:3.8-alpine3.14
 
 # Set the working directory for the app.
 WORKDIR /opt/app
@@ -15,18 +15,21 @@ COPY /entrypoint.sh /opt/app/entrypoint.sh
 COPY --from=0 /opt/app/* /opt/app/
 
 RUN cd /opt/app && \
+    # Install build tools
+    apk add --no-cache build-base && \
     # Install requirements using pip
-    pip3 install -r requirements.txt && \
+    pip3 install --no-cache-dir -r requirements.txt && \
     # Make the entrypoint executable
     chmod +x entrypoint.sh && \
     # Fix spotipy to show the URL on terminal instead of trying to open a browser
     sed -i.bak '419s/None/False/' /usr/local/lib/python3.8/site-packages/spotipy/oauth2.py && \
     # Clean up.
-    rm -r .gitignore HEAD README.md branches config copy.png description example.gif folder.png hooks index info logs musicplayer.png objects packed-refs redirecturi.png refs setup.png terminal.png 
+    rm -r .gitignore HEAD README.md branches config copy.png description example.gif folder.png hooks index info logs musicplayer.png objects packed-refs redirecturi.png refs setup.png terminal.png && \
+    apk del build-base
 
 # Declare mounting points.
 VOLUME [ "/app" ]
 VOLUME [ "/downloads" ]
 
 ENTRYPOINT [ "/opt/app/entrypoint.sh" ]
-CMD [ "/bin/bash" ]
+CMD [ "/bin/sh" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,32 @@
+# Pull git base image for downloading the repo.
+FROM alpine/git:latest
+
+# Clone the git repo.
+RUN git clone https://github.com/piyx/YoutubeSpotifyDL.git /opt/app
+
+# Pull base image for python.
+FROM python:3.8-slim
+
+# Set the working directory for the app.
+WORKDIR /opt/app
+
+# Copy entrypoint.sh and the git repo in the working directory.
+COPY /entrypoint.sh /opt/app/entrypoint.sh
+COPY --from=0 /opt/app/* /opt/app/
+
+RUN cd /opt/app && \
+    # Install requirements using pip
+    pip3 install -r requirements.txt && \
+    # Make the entrypoint executable
+    chmod +x entrypoint.sh && \
+    # Fix spotipy to show the URL on terminal instead of trying to open a browser
+    sed -i.bak '419s/None/False/' /usr/local/lib/python3.8/site-packages/spotipy/oauth2.py && \
+    # Clean up.
+    rm -r .gitignore HEAD README.md branches config copy.png description example.gif folder.png hooks index info logs musicplayer.png objects packed-refs redirecturi.png refs setup.png terminal.png 
+
+# Declare mounting points.
+VOLUME [ "/app" ]
+VOLUME [ "/downloads" ]
+
+ENTRYPOINT [ "/opt/app/entrypoint.sh" ]
+CMD [ "/bin/bash" ]

--- a/README.md
+++ b/README.md
@@ -48,6 +48,48 @@ To install all modules run `pip install -r requirements.txt`
 ![](imgs/folder.png)
 ![](imgs/musicplayer.png)
 
+## Docker Setup 
+You can build a Docker image of this project from the provided Dockerfile.
+
+***Don't forget the dot at the end of the command.***
+
+```sh
+docker build -t youtubespotifydl:latest .
+```
+Before running the image you need to create a `.env` file with the following contents:
+
+`SPOTIFY_USER_ID=your_user_id`  
+`SPOTIFY_CLIENT_ID=your_client_id`  
+`SPOTIFY_CLIENT_SECRET=your_client_secret`  
+`SPOTIFY_REDIRECT_URI=http://server_ip:8888/callback`
+
+For the `SPOTIFY_REDIRECT_URI` variable you will have to provide the Docker Host IP, Docker Container IP or, if you are trying this on a VPS, the public IP of the VPS.
+
+***For some reason `localhost` will not work inside the container. Also make sure to add the `SPOTIFY_REDIRECT_URI` in the Spotify Developer Dashboard***
+
+After building and setting up the `.env` file, you can run the tool with this command:
+
+```sh
+docker run --rm -it --env-file .env -v /host/path/to/store/downloads:/downloads -v /host/path/to/store/app:/app youtubespotifydl:latest
+```
+The container will go through the start up sequence and after it is done it will drop you in a terminal inside the container.
+To start the tool just type the following command inside the terminal:
+```sh
+python3 main.py
+```
+The app will generate an URL, which you need to open in your browser. The URL will redircet you to authorize with your Spotify Account and afterwards the browser
+will generate another URL in the address bar that you will need to copy and paste in the terminal. 
+
+***You are now able to download your music through a Docker Container***
+
+#### Explanation:
+1. **--rm** - this option will delete the container after you exit from it.
+2. **-it** - this option will provide a interactive shell inside the container
+3. **--env-file .env** - this is the location of the `.env` file.
+4. **-v /host/path/to/store/downloads:/downloads** - this is to link a folder on your host to a folder in the container. In this case we are linking the downloads folder so that our downloaded muisc persists after the container is shutdown and removed. On the left of the `:` is the host location and on the right is the location inside the container. Feel free to change the left side.
+5. **-v /host/path/to/store/app:/app** - same as the point above but for persisting the application itself. This option might be more useful for debuging the app or manual updates with the latest changes but that's about it.
+6. **youtubespotifydl:latest** - the actual image name. ***NOTE: If you changed the -t paramater during the build process you will have to reflect that change here as well***
+
 ## How it works
 
 ```

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 # Declare variables to be available to Docker.
 export SPOTIFY_USER_ID="${SPOTIFY_USER_ID}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+# Declare variables to be available to Docker.
+export SPOTIFY_USER_ID="${SPOTIFY_USER_ID}"
+export SPOTIFY_CLIENT_ID="${SPOTIFY_CLIENT_ID}"
+export SPOTIFY_CLIENT_SECRET="${SPOTIFY_CLIENT_SECRET}"
+export SPOTIFY_REDIRECT_URI="${SPOTIFY_REDIRECT_URI}"
+
+# Generate .env file just in case the above fails for some reason.
+cat << EOF > .env
+
+SPOTIFY_USER_ID=${SPOTIFY_USER_ID}
+SPOTIFY_CLIENT_ID=${SPOTIFY_CLIENT_ID}
+SPOTIFY_CLIENT_SECRET=${SPOTIFY_CLIENT_SECRET}
+SPOTIFY_REDIRECT_URI=${SPOTIFY_REDIRECT_URI}
+
+EOF
+
+# Expose app files to the host.
+if [ ! -d "/app" ]; then
+  ln -s /opt/app/* /app
+elif [ -z "$(ls -A /app)" ]; then
+  cp -a /opt/app/. /app
+fi
+
+exec "$@"


### PR DESCRIPTION
I did this because I hate standalone Python apps and I hate Python it self.
But on the other hand I love Python apps running inside Docker containers. 
Less time spend on dealing with requierments issues and more time spend on actually using the app and maybe improving it.

I've added extensive comments in the Dockerfile, entrypoint.sh and the README.md files to easily understand what all the commands do and how to use it.
I understand it is bit janky and that it needs work but it is usable to some degree.
I noticed that it won't download from YouTube when the song has some special characters in the title, but this might be a Python thing and not releated to Docker itself.

Let me know what you think and we might improve on this.
Thank you for this awesome tool.

**UPDATE 02.10.2021**
This update reduces the image footprint on the host system.
The base image python3.8-slim has been replaced with python3.8-alpine3.14.
The image is reduced to 58Mb (compressed i.e when downloading from DockerHub) and 104Mb when decompressed on the host system.
The problem from above with YouTube still exists. I opened a Issue for it.