### PR TITLE
Pafy Fix

### DIFF
--- a/downloader.py
+++ b/downloader.py
@@ -1,7 +1,8 @@
 import re
 import os
 
-import pafy
+# import pafy
+from pytube import YouTube as youtube_dl;
 import requests
 from mutagen.mp4 import MP4, MP4Cover
 
@@ -9,10 +10,17 @@ from utils import Song
 from youtube import Youtube
 
 
-def download_song_from_yt(vid_url: str, song_name: str) -> None:
+def download_song_from_yt(vid_url: str, song_name: str, song: Song) -> None:
     """Download song in the current directory and rename it"""
-    vid = pafy.new(vid_url)
-    vid.getbestaudio(preftype="m4a").download(f"{song_name}.m4a")
+    # vid = pafy.new(vid_url)
+    # vid.getbestaudio(preftype="m4a").download(f"{song_name}.m4a")
+    
+    def completed(*args):
+        print(f"Downloaded {song_name}");
+        addtags(os.path.join(os.getcwd(), song_name+".m4a"), song);
+    vid = youtube_dl(vid_url, on_complete_callback=completed);
+    ys = vid.streams.filter(only_audio=True, file_extension='mp4').last();
+    ys.download(output_path=os.getcwd(), filename=song_name+".m4a");
 
 
 def addtags(songpath: str, song: Song) -> None:
@@ -46,8 +54,8 @@ def download(song: Song) -> None:
             print(f"Skipping {song_name} : Already Downloaded")
             return
 
-        download_song_from_yt(song.vidurl, song_name)
-        addtags(song_path, song)
+        download_song_from_yt(song.vidurl, song_name, song)
+        # addtags(song_path, song)
     except Exception as e:
         if os.path.exists(song_path):
             os.remove(song_path)

--- a/downloader.py
+++ b/downloader.py
@@ -1,8 +1,7 @@
 import re
 import os
 
-# import pafy
-from pytube import YouTube as youtube_dl;
+from pytube import YouTube as youtube_dl
 import requests
 from mutagen.mp4 import MP4, MP4Cover
 
@@ -16,11 +15,12 @@ def download_song_from_yt(vid_url: str, song_name: str, song: Song) -> None:
     # vid.getbestaudio(preftype="m4a").download(f"{song_name}.m4a")
     
     def completed(*args):
-        print(f"Downloaded {song_name}");
-        addtags(os.path.join(os.getcwd(), song_name+".m4a"), song);
-    vid = youtube_dl(vid_url, on_complete_callback=completed);
-    ys = vid.streams.filter(only_audio=True, file_extension='mp4').last();
-    ys.download(output_path=os.getcwd(), filename=song_name+".m4a");
+        addtags(os.path.join(os.getcwd(), song_name+".m4a"), song)
+        print(f"Downloaded {song_name}.")
+    vid = youtube_dl(vid_url, on_complete_callback=completed)
+    ys = vid.streams.get_audio_only()
+    assert ys != None, f"Pytube returned no audio only streams for {song_name}"
+    ys.download(output_path=os.getcwd(), filename=song_name+".m4a")
 
 
 def addtags(songpath: str, song: Song) -> None:
@@ -42,7 +42,7 @@ def download(song: Song) -> None:
     song_name = re.sub(
         INVALID, "", f"{song.artist} {song.title}"
     )  # Remove invalid chars
-    print(f"Downloading {song_name}")
+    print(f"Downloading {song_name}...")
     try:
         if song.vidurl is None:
             vid_id = Youtube.get_video_id(song_name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-pafy==0.5.5
 mutagen==1.45.1
 spotipy==2.19.0
 requests==2.25.0
@@ -6,3 +5,4 @@ python-dotenv==0.19.1
 PyInquirer==1.0.3
 ytmusicapi==0.19.3
 youtube-dl==2021.6.6
+pytube==11.0.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,4 +5,4 @@ python-dotenv==0.19.1
 PyInquirer==1.0.3
 ytmusicapi==0.19.3
 youtube-dl==2021.6.6
-pytube==11.0.1
+pytube==11.0.2


### PR DESCRIPTION
Pafy broke due to Youtube removing dislikes so now I changed it to using pytube to download youtube videos in m4a format. The last commit to pafy was 2 years ago so it's not surprising it stopped working. This replacement works just fine, and way faster than pafy (at least for me). Only thing is there's no progress indicator I'm not sure how I'd do that either.